### PR TITLE
Bug fix processing orders

### DIFF
--- a/omod/src/main/java/org/openmrs/module/pharmacyapp/page/controller/DrugOrderPageController.java
+++ b/omod/src/main/java/org/openmrs/module/pharmacyapp/page/controller/DrugOrderPageController.java
@@ -102,7 +102,9 @@ public class DrugOrderPageController {
         int patientId = Integer.parseInt(request.getParameter("patientId"));
         int presciberId = Integer.parseInt(request.getParameter("prescriberId"));
         int receiptId = 0;
+        Context.addProxyPrivilege("View Users");
         User prescriber = Context.getUserService().getUser(presciberId);
+        Context.removeProxyPrivilege("View Users");
         Double totalCharges = Double.parseDouble(request.getParameter("totalCharges"));
 
         BigDecimal waiverAmount = null;


### PR DESCRIPTION
Give user temporary privileges to View Users. This is required so that the prescriber of the order can be fetched from the database and linked to the bill sent over to the cashier.